### PR TITLE
change FriendBot default url to https

### DIFF
--- a/lib/mobius/client/friend_bot.rb
+++ b/lib/mobius/client/friend_bot.rb
@@ -20,7 +20,7 @@ class Mobius::Client::FriendBot
 
   def http
     # Mobius::Client.mobius_host
-    Faraday.new("http://localhost:4000") do |c|
+    Faraday.new("https://localhost:4000", :ssl => {:verify => false}) do |c|
       c.request :url_encoded
       c.response :json, content_type: /\bjson$/
       c.adapter Faraday.default_adapter


### PR DESCRIPTION
for actual release though i guess we will change it to beta.mobius.network ? or regular mobius.network maybe? friendbot might always be testnet?