### PR TITLE
Cleanup balance related methods in App class

### DIFF
--- a/lib/mobius/client.rb
+++ b/lib/mobius/client.rb
@@ -1,3 +1,5 @@
+require "bigdecimal"
+require "bigdecimal/util"
 require "constructor_shortcut"
 require "dry-initializer"
 require "stellar-sdk"

--- a/lib/mobius/client/app.rb
+++ b/lib/mobius/client/app.rb
@@ -1,6 +1,3 @@
-require "bigdecimal"
-require "bigdecimal/util"
-
 # Interface to user balance in application.
 class Mobius::Client::App
   extend Dry::Initializer

--- a/lib/mobius/client/app.rb
+++ b/lib/mobius/client/app.rb
@@ -2,7 +2,6 @@ require "bigdecimal"
 require "bigdecimal/util"
 
 # Interface to user balance in application.
-# rubocop:disable Metrics/ClassLength
 class Mobius::Client::App
   extend Dry::Initializer
 
@@ -23,13 +22,13 @@ class Mobius::Client::App
   # @return [Float] User balance.
   def balance
     validate!
-    balance_object["balance"].to_f
+    user_account.balance
   end
 
   # Returns application balance.
   # @return [Float] Application balance.
   def app_balance
-    app_balance_object["balance"].to_f
+    app_account.balance
   end
 
   # Makes payment.
@@ -113,25 +112,7 @@ class Mobius::Client::App
 
   def validate!
     raise Mobius::Client::Error::AuthorisationMissing unless authorized?
-    raise Mobius::Client::Error::TrustlineMissing if balance_object.nil?
-  end
-
-  def limit
-    balance_object["limit"].to_f
-  end
-
-  def balance_object
-    find_balance(user_account.info.balances)
-  end
-
-  def app_balance_object
-    find_balance(app_account.info.balances)
-  end
-
-  def find_balance(balances)
-    balances.find do |s|
-      s["asset_code"] == Mobius::Client.asset_code && s["asset_issuer"] == Mobius::Client.asset_issuer
-    end
+    raise Mobius::Client::Error::TrustlineMissing unless user_account.trustline_exists?
   end
 
   def app_keypair
@@ -165,4 +146,3 @@ class Mobius::Client::App
 
   FEE = 100
 end
-# rubocop:enable Metrics/ClassLength

--- a/lib/mobius/client/blockchain/account.rb
+++ b/lib/mobius/client/blockchain/account.rb
@@ -12,7 +12,7 @@ class Mobius::Client::Blockchain::Account
   # @return [Boolean] true if trustline exists
   def trustline_exists?(asset = Mobius::Client.stellar_asset)
     balance = find_balance(asset)
-    (balance && !balance.dig("limit").to_f.zero?) || false
+    (balance && !balance.dig("limit").to_d.zero?) || false
   end
 
   # Returns balance for given asset
@@ -20,7 +20,7 @@ class Mobius::Client::Blockchain::Account
   # @return [Float] Balance value.
   def balance(asset = Mobius::Client.stellar_asset)
     balance = find_balance(asset)
-    balance && balance.dig("balance").to_f
+    balance && balance.dig("balance").to_d
   end
 
   # Returns true if given keypair is added as cosigner to current account.


### PR DESCRIPTION
Remove unnecessary (seemingly) methods for retrieving balance in `Mobius::Client::App` class. Also used explicit trustline existence check in `validate!` method