### PR TITLE
Get rid of the deprecated rbnacl-libsodium dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,17 @@ env:
   global:
     - CC_TEST_REPORTER_ID=b73e557e34c0841f1f534b98bb01a3346cdad5eb9913416dca9ec1350af6ac09
 
+dist: xenial
 language: ruby
 rvm:
   - 2.3
   - 2.4
   - 2.5
 cache: bundler
+addons:
+  apt:
+    packages:
+    - libsodium-dev
 before_install:
   - gem update --system && gem install --no-document bundler
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
@@ -18,5 +23,5 @@ after_script:
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
 script:
   - bundle exec rake
-  - bundle exec bundle-audit check --update --ignore CVE-2016-10545
+  - bundle exec bundle-audit check --update
   - bundle exec rubocop

--- a/examples/auth/Gemfile.lock
+++ b/examples/auth/Gemfile.lock
@@ -7,15 +7,15 @@ PATH
       faraday (>= 0.14)
       faraday_middleware (~> 0.12, >= 0.12.2)
       jwt (~> 1.5, >= 1.5.6)
-      stellar-sdk (~> 0.3)
+      stellar-sdk (~> 0.6)
       thor (~> 0.20)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.2.1)
-      activesupport (= 5.2.1)
-    activesupport (5.2.1)
+    activemodel (5.2.2)
+      activesupport (= 5.2.2)
+    activesupport (5.2.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -28,7 +28,7 @@ GEM
     digest-crc (0.4.1)
     dry-initializer (2.5.0)
     excon (0.62.0)
-    faraday (0.15.3)
+    faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
     faraday-digestauth (0.3.0)
       faraday (~> 0.7)
@@ -57,8 +57,6 @@ GEM
       rack
     rbnacl (6.0.0)
       ffi
-    rbnacl-libsodium (1.0.16)
-      rbnacl (>= 3.0.1)
     sinatra (2.0.3)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -67,19 +65,18 @@ GEM
     slim (3.0.9)
       temple (>= 0.7.6, < 0.9)
       tilt (>= 1.3.3, < 2.1)
-    stellar-base (0.17.0)
+    stellar-base (0.18.0)
       activesupport (>= 5.2.0)
       base32
       digest-crc
-      rbnacl
-      rbnacl-libsodium (~> 1.0.16)
+      rbnacl (>= 6.0)
       xdr (~> 3.0.0)
-    stellar-sdk (0.5.0)
+    stellar-sdk (0.6.0)
       activesupport (>= 5.2.0)
       contracts (~> 0.16)
       excon (~> 0.44, >= 0.44.4)
       hyperclient (~> 0.7)
-      stellar-base (>= 0.16.0)
+      stellar-base (>= 0.18.0)
       toml-rb (~> 1.1, >= 1.1.1)
     temple (0.8.0)
     thor (0.20.3)

--- a/mobius-client.gemspec
+++ b/mobius-client.gemspec
@@ -44,6 +44,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "faraday", ">= 0.14"
   spec.add_dependency "faraday_middleware", "~> 0.12", ">= 0.12.2"
   spec.add_dependency "jwt", "~> 1.5", ">= 1.5.6"
-  spec.add_dependency "stellar-sdk", "~> 0.3"
+  spec.add_dependency "stellar-sdk", "~> 0.6"
   spec.add_dependency "thor", "~> 0.20"
 end


### PR DESCRIPTION
[rbnacl-libsodium](https://github.com/crypto-rb/rbnacl-libsodium) has been deprecated. This PR updates our Stellar deps to include stellar/ruby-stellar-base#46 and fixes Travis configuration.