### PR TITLE
Fix signer check to understand the response format of Horizon 0.17+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
 cache: bundler
 addons:
   apt:

--- a/lib/mobius/client/blockchain/account.rb
+++ b/lib/mobius/client/blockchain/account.rb
@@ -82,7 +82,7 @@ class Mobius::Client::Blockchain::Account
 
   # TODO: Think of adding weight check here
   def find_signer(address)
-    info.signers.find { |s| s["public_key"] == address }
+    info.signers.find { |s| s["public_key"] == address || s["key"] == address }
   rescue Faraday::ResourceNotFound
     raise Mobius::Client::Error::AccountMissing
   end

--- a/mobius-client.gemspec
+++ b/mobius-client.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "bundler-audit", "~> 0.6.0"
   spec.add_development_dependency "httplog", "~> 1.0", ">= 1.0.2"
   spec.add_development_dependency "rake", "~> 12.0"

--- a/spec/fixtures/vcr_cassettes/account/cosigner_exists.yml
+++ b/spec/fixtures/vcr_cassettes/account/cosigner_exists.yml
@@ -100,7 +100,6 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GAZDIAPACN6EMNHFNEDUVFTTGL45DVZJVXEGJDNKTVGMHI5YN5LXLNR4",
               "weight": 1,
               "key": "GAZDIAPACN6EMNHFNEDUVFTTGL45DVZJVXEGJDNKTVGMHI5YN5LXLNR4",
               "type": "ed25519_public_key"

--- a/spec/fixtures/vcr_cassettes/account/missing_cosigner.yml
+++ b/spec/fixtures/vcr_cassettes/account/missing_cosigner.yml
@@ -93,7 +93,6 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GAJ5ZJZP6U2THEOJU45Z4NJKYXDK724C5PFPLF3OV5POIQH4OQVNWJKU",
               "weight": 1,
               "key": "GAJ5ZJZP6U2THEOJU45Z4NJKYXDK724C5PFPLF3OV5POIQH4OQVNWJKU",
               "type": "ed25519_public_key"

--- a/spec/fixtures/vcr_cassettes/account/missing_cosigner_on_create.yml
+++ b/spec/fixtures/vcr_cassettes/account/missing_cosigner_on_create.yml
@@ -100,97 +100,81 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GDWOCDFQYM5V4MOHQBLCZDAFGVTMSVRCDJLK2QQHRYKEEXTB2RQKJCTY",
               "weight": 1,
               "key": "GDWOCDFQYM5V4MOHQBLCZDAFGVTMSVRCDJLK2QQHRYKEEXTB2RQKJCTY",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GCRPCCM4XURKRJVWI37TNNLAB2JDFPQ2IMTM6PVTM2HR3DWVAGPH3PTA",
               "weight": 1,
               "key": "GCRPCCM4XURKRJVWI37TNNLAB2JDFPQ2IMTM6PVTM2HR3DWVAGPH3PTA",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GATXEVGSMRHDFIZUSXTSBFVJHW3JQE2WVD7X3YXT7GWGWP3FF4R555XD",
               "weight": 1,
               "key": "GATXEVGSMRHDFIZUSXTSBFVJHW3JQE2WVD7X3YXT7GWGWP3FF4R555XD",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GCBXTFZZK3SSJIOAJUUYVWJOJ55YMPKTCBB2DOTMXCQRRJ666DPXFP2D",
               "weight": 1,
               "key": "GCBXTFZZK3SSJIOAJUUYVWJOJ55YMPKTCBB2DOTMXCQRRJ666DPXFP2D",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GDLLEGZBTRY7PSTOPNWYB54TFZNFWCRVKL36V7VO5DPXVKCPFLBJ5EB3",
               "weight": 1,
               "key": "GDLLEGZBTRY7PSTOPNWYB54TFZNFWCRVKL36V7VO5DPXVKCPFLBJ5EB3",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GDNCLOHRNENOMGLD7QTWHIKZVYBEGOJHIB5QFQQ5TWDM7J7MU2X27O6I",
               "weight": 1,
               "key": "GDNCLOHRNENOMGLD7QTWHIKZVYBEGOJHIB5QFQQ5TWDM7J7MU2X27O6I",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GAFMXIILI6I2LWSGYZ3XCTFDH7F55IIVDDS5TPC6WU6J6RE67U6D3EEO",
               "weight": 1,
               "key": "GAFMXIILI6I2LWSGYZ3XCTFDH7F55IIVDDS5TPC6WU6J6RE67U6D3EEO",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GDMAKXVV6QQ35DMTVKHSEWUG3NKROZNPQ5XBLENQDC5MLY7TN6RM2REJ",
               "weight": 1,
               "key": "GDMAKXVV6QQ35DMTVKHSEWUG3NKROZNPQ5XBLENQDC5MLY7TN6RM2REJ",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GAG3WXOHBJVYI5M34FDRAGQ7WWNVJCBDMABKL4IUUNU4AOQO63NK3NM6",
               "weight": 1,
               "key": "GAG3WXOHBJVYI5M34FDRAGQ7WWNVJCBDMABKL4IUUNU4AOQO63NK3NM6",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GCJSSV4BD3KUWE7TAKHWVDTIQUSXF7GPWTUIWTPHKIUC6TGXRBJ6CM7W",
               "weight": 1,
               "key": "GCJSSV4BD3KUWE7TAKHWVDTIQUSXF7GPWTUIWTPHKIUC6TGXRBJ6CM7W",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBBYNJ6WASTU4PG6UQE6E7F72T7MLB3E6Y7JY46R2SBLRILRMMCU3KD7",
               "weight": 1,
               "key": "GBBYNJ6WASTU4PG6UQE6E7F72T7MLB3E6Y7JY46R2SBLRILRMMCU3KD7",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GCKP7KGMPCUW3PTDVQE7NEL4LKMQQUODSKTKL7AB7I7ZOGFUX52YDJCS",
               "weight": 1,
               "key": "GCKP7KGMPCUW3PTDVQE7NEL4LKMQQUODSKTKL7AB7I7ZOGFUX52YDJCS",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GD6GO2G2MXOMEZIPPRSXWOE4AS5MG65H2F5GZSTB4TX6CNI4LINSCC73",
               "weight": 1,
               "key": "GD6GO2G2MXOMEZIPPRSXWOE4AS5MG65H2F5GZSTB4TX6CNI4LINSCC73",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBWVAAPRRYCTZR3VDZAG6A5B2G4ZZVNQQWKLCDWMMAWTST556GYV3JFO",
               "weight": 1,
               "key": "GBWVAAPRRYCTZR3VDZAG6A5B2G4ZZVNQQWKLCDWMMAWTST556GYV3JFO",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBHIGHEVKMF5K3IZT7UPY5A2Q4Y7Z4JF3TSZWQTLF4PPLVF6HGQVNBGD",
               "weight": 1,
               "key": "GBHIGHEVKMF5K3IZT7UPY5A2Q4Y7Z4JF3TSZWQTLF4PPLVF6HGQVNBGD",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GAHLSSCRJ32C2XOFLDC2KUC2X2NLZT55X4AVWBITERBEDBBJ3UA7YDK7",
               "weight": 10,
               "key": "GAHLSSCRJ32C2XOFLDC2KUC2X2NLZT55X4AVWBITERBEDBBJ3UA7YDK7",
               "type": "ed25519_public_key"

--- a/spec/fixtures/vcr_cassettes/account/missing_trustline.yml
+++ b/spec/fixtures/vcr_cassettes/account/missing_trustline.yml
@@ -93,7 +93,6 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GAJ5ZJZP6U2THEOJU45Z4NJKYXDK724C5PFPLF3OV5POIQH4OQVNWJKU",
               "weight": 1,
               "key": "GAJ5ZJZP6U2THEOJU45Z4NJKYXDK724C5PFPLF3OV5POIQH4OQVNWJKU",
               "type": "ed25519_public_key"

--- a/spec/fixtures/vcr_cassettes/account/missing_trustline_on_create.yml
+++ b/spec/fixtures/vcr_cassettes/account/missing_trustline_on_create.yml
@@ -93,7 +93,6 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBHTFSK264PWZNVHDDV3ORIAEPBFT3M66ZLG6C4BSC4IKT2USERDXU52",
               "weight": 1,
               "key": "GBHTFSK264PWZNVHDDV3ORIAEPBFT3M66ZLG6C4BSC4IKT2USERDXU52",
               "type": "ed25519_public_key"

--- a/spec/fixtures/vcr_cassettes/account/trustline_exists.yml
+++ b/spec/fixtures/vcr_cassettes/account/trustline_exists.yml
@@ -100,7 +100,6 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GAZDIAPACN6EMNHFNEDUVFTTGL45DVZJVXEGJDNKTVGMHI5YN5LXLNR4",
               "weight": 1,
               "key": "GAZDIAPACN6EMNHFNEDUVFTTGL45DVZJVXEGJDNKTVGMHI5YN5LXLNR4",
               "type": "ed25519_public_key"

--- a/spec/fixtures/vcr_cassettes/app/app_balance.yml
+++ b/spec/fixtures/vcr_cassettes/app/app_balance.yml
@@ -202,13 +202,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "weight": 10,
               "key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "type": "ed25519_public_key"

--- a/spec/fixtures/vcr_cassettes/app/app_charge.yml
+++ b/spec/fixtures/vcr_cassettes/app/app_charge.yml
@@ -198,7 +198,6 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
@@ -315,13 +314,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "weight": 10,
               "key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "type": "ed25519_public_key"
@@ -438,13 +435,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "weight": 10,
               "key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "type": "ed25519_public_key"
@@ -621,7 +616,6 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
@@ -738,13 +732,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "weight": 10,
               "key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "type": "ed25519_public_key"

--- a/spec/fixtures/vcr_cassettes/app/app_charge_insufficient_funds.yml
+++ b/spec/fixtures/vcr_cassettes/app/app_charge_insufficient_funds.yml
@@ -198,13 +198,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "weight": 10,
               "key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "type": "ed25519_public_key"

--- a/spec/fixtures/vcr_cassettes/app/app_charge_with_target.yml
+++ b/spec/fixtures/vcr_cassettes/app/app_charge_with_target.yml
@@ -198,7 +198,6 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
@@ -315,13 +314,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "weight": 10,
               "key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "type": "ed25519_public_key"
@@ -438,13 +435,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GB4XMZJPWQS4LYAOZLEWYT6RCEX2J2QAZ3JLOHSBSTIWSSGCU4BQTCQO",
               "weight": 1,
               "key": "GB4XMZJPWQS4LYAOZLEWYT6RCEX2J2QAZ3JLOHSBSTIWSSGCU4BQTCQO",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GCOCYI2CTR2NH4QNJXTND7EHRLD7U3WZBR63OMVTZM4AXGZ4FIL2XR2Y",
               "weight": 10,
               "key": "GCOCYI2CTR2NH4QNJXTND7EHRLD7U3WZBR63OMVTZM4AXGZ4FIL2XR2Y",
               "type": "ed25519_public_key"
@@ -561,13 +556,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "weight": 10,
               "key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "type": "ed25519_public_key"
@@ -744,13 +737,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GB4XMZJPWQS4LYAOZLEWYT6RCEX2J2QAZ3JLOHSBSTIWSSGCU4BQTCQO",
               "weight": 1,
               "key": "GB4XMZJPWQS4LYAOZLEWYT6RCEX2J2QAZ3JLOHSBSTIWSSGCU4BQTCQO",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GCOCYI2CTR2NH4QNJXTND7EHRLD7U3WZBR63OMVTZM4AXGZ4FIL2XR2Y",
               "weight": 10,
               "key": "GCOCYI2CTR2NH4QNJXTND7EHRLD7U3WZBR63OMVTZM4AXGZ4FIL2XR2Y",
               "type": "ed25519_public_key"
@@ -867,7 +858,6 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
@@ -984,13 +974,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "weight": 10,
               "key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "type": "ed25519_public_key"

--- a/spec/fixtures/vcr_cassettes/app/app_payout_account_missing.yml
+++ b/spec/fixtures/vcr_cassettes/app/app_payout_account_missing.yml
@@ -198,7 +198,6 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
@@ -315,13 +314,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "weight": 10,
               "key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "type": "ed25519_public_key"

--- a/spec/fixtures/vcr_cassettes/app/app_payout_to_target.yml
+++ b/spec/fixtures/vcr_cassettes/app/app_payout_to_target.yml
@@ -198,7 +198,6 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
@@ -315,13 +314,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "weight": 10,
               "key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "type": "ed25519_public_key"
@@ -438,13 +435,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GB4XMZJPWQS4LYAOZLEWYT6RCEX2J2QAZ3JLOHSBSTIWSSGCU4BQTCQO",
               "weight": 1,
               "key": "GB4XMZJPWQS4LYAOZLEWYT6RCEX2J2QAZ3JLOHSBSTIWSSGCU4BQTCQO",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GCOCYI2CTR2NH4QNJXTND7EHRLD7U3WZBR63OMVTZM4AXGZ4FIL2XR2Y",
               "weight": 10,
               "key": "GCOCYI2CTR2NH4QNJXTND7EHRLD7U3WZBR63OMVTZM4AXGZ4FIL2XR2Y",
               "type": "ed25519_public_key"
@@ -561,13 +556,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "weight": 10,
               "key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "type": "ed25519_public_key"
@@ -744,13 +737,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GB4XMZJPWQS4LYAOZLEWYT6RCEX2J2QAZ3JLOHSBSTIWSSGCU4BQTCQO",
               "weight": 1,
               "key": "GB4XMZJPWQS4LYAOZLEWYT6RCEX2J2QAZ3JLOHSBSTIWSSGCU4BQTCQO",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GCOCYI2CTR2NH4QNJXTND7EHRLD7U3WZBR63OMVTZM4AXGZ4FIL2XR2Y",
               "weight": 10,
               "key": "GCOCYI2CTR2NH4QNJXTND7EHRLD7U3WZBR63OMVTZM4AXGZ4FIL2XR2Y",
               "type": "ed25519_public_key"
@@ -867,7 +858,6 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
@@ -984,13 +974,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "weight": 10,
               "key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "type": "ed25519_public_key"

--- a/spec/fixtures/vcr_cassettes/app/app_payout_to_user.yml
+++ b/spec/fixtures/vcr_cassettes/app/app_payout_to_user.yml
@@ -198,7 +198,6 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
@@ -315,13 +314,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "weight": 10,
               "key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "type": "ed25519_public_key"
@@ -438,13 +435,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "weight": 10,
               "key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "type": "ed25519_public_key"
@@ -621,7 +616,6 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
@@ -738,13 +732,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "weight": 10,
               "key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "type": "ed25519_public_key"

--- a/spec/fixtures/vcr_cassettes/app/app_payout_trustline_missing.yml
+++ b/spec/fixtures/vcr_cassettes/app/app_payout_trustline_missing.yml
@@ -198,7 +198,6 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
@@ -315,13 +314,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "weight": 10,
               "key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "type": "ed25519_public_key"

--- a/spec/fixtures/vcr_cassettes/app/app_transfer_account_missing.yml
+++ b/spec/fixtures/vcr_cassettes/app/app_transfer_account_missing.yml
@@ -109,7 +109,6 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
@@ -228,13 +227,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "weight": 10,
               "key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "type": "ed25519_public_key"

--- a/spec/fixtures/vcr_cassettes/app/app_transfer_correct.yml
+++ b/spec/fixtures/vcr_cassettes/app/app_transfer_correct.yml
@@ -198,7 +198,6 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
@@ -315,13 +314,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "weight": 10,
               "key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "type": "ed25519_public_key"
@@ -438,13 +435,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GB4XMZJPWQS4LYAOZLEWYT6RCEX2J2QAZ3JLOHSBSTIWSSGCU4BQTCQO",
               "weight": 1,
               "key": "GB4XMZJPWQS4LYAOZLEWYT6RCEX2J2QAZ3JLOHSBSTIWSSGCU4BQTCQO",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GCOCYI2CTR2NH4QNJXTND7EHRLD7U3WZBR63OMVTZM4AXGZ4FIL2XR2Y",
               "weight": 10,
               "key": "GCOCYI2CTR2NH4QNJXTND7EHRLD7U3WZBR63OMVTZM4AXGZ4FIL2XR2Y",
               "type": "ed25519_public_key"
@@ -561,13 +556,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "weight": 10,
               "key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "type": "ed25519_public_key"
@@ -744,13 +737,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GB4XMZJPWQS4LYAOZLEWYT6RCEX2J2QAZ3JLOHSBSTIWSSGCU4BQTCQO",
               "weight": 1,
               "key": "GB4XMZJPWQS4LYAOZLEWYT6RCEX2J2QAZ3JLOHSBSTIWSSGCU4BQTCQO",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GCOCYI2CTR2NH4QNJXTND7EHRLD7U3WZBR63OMVTZM4AXGZ4FIL2XR2Y",
               "weight": 10,
               "key": "GCOCYI2CTR2NH4QNJXTND7EHRLD7U3WZBR63OMVTZM4AXGZ4FIL2XR2Y",
               "type": "ed25519_public_key"
@@ -867,7 +858,6 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
@@ -984,13 +974,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "weight": 10,
               "key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "type": "ed25519_public_key"

--- a/spec/fixtures/vcr_cassettes/app/app_transfer_trustline_missing.yml
+++ b/spec/fixtures/vcr_cassettes/app/app_transfer_trustline_missing.yml
@@ -109,7 +109,6 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
@@ -228,13 +227,11 @@ http_interactions:
           ],
           "signers": [
             {
-              "public_key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "weight": 1,
               "key": "GBG4NNZZNVSCQ4SZETMHY6NJUZRMZJ27IPC4UX53LEUVKVRARFETTR4H",
               "type": "ed25519_public_key"
             },
             {
-              "public_key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "weight": 10,
               "key": "GBTYV66THKPJR4UU5ZHONLRZJKWGGVOCYWVYOTWKJU75VN54K26C5VYG",
               "type": "ed25519_public_key"


### PR DESCRIPTION
`public_key` field in signer info has been deprecated and removed from [Horizon 0.17](https://github.com/howardtw/go/blob/master/services/horizon/CHANGELOG.md#breaking-changes), we should use `key` field instead.